### PR TITLE
Fixed Routing for All Entities

### DIFF
--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -1,0 +1,71 @@
+class AttendancesController < ApplicationController
+    before_action :set_attendance, only: %i[ show edit update destroy ]
+  
+    # GET /attendances or /attendances.json
+    def index
+      @attendances = Attendance.all
+    end
+  
+    # GET /attendances/1 or /attendances/1.json
+    def show
+    end
+  
+    # GET /attendances/new
+    def new
+      @attendance = Attendance.new
+    end
+  
+    # GET /attendances/1/edit
+    def edit
+    end
+  
+    # POST /attendances or /attendances.json
+    def create
+      @attendance = Attendance.new(attendance_params)
+  
+      respond_to do |format|
+        if @attendance.save
+          format.html { redirect_to attendance_url(@attendance), notice: "Attendance was successfully created." }
+          format.json { render :show, status: :created, location: @attendance }
+        else
+          format.html { render :new, status: :unprocessable_entity }
+          format.json { render json: @attendance.errors, status: :unprocessable_entity }
+        end
+      end
+    end
+  
+    # PATCH/PUT /attendances/1 or /attendances/1.json
+    def update
+      respond_to do |format|
+        if @attendance.update(attendance_params)
+          format.html { redirect_to attendance_url(@attendance), notice: "Attendance was successfully updated." }
+          format.json { render :show, status: :ok, location: @attendance }
+        else
+          format.html { render :edit, status: :unprocessable_entity }
+          format.json { render json: @attendance.errors, status: :unprocessable_entity }
+        end
+      end
+    end
+  
+    # DELETE /attendances/1 or /attendances/1.json
+    def destroy
+      @attendance.destroy
+  
+      respond_to do |format|
+        format.html { redirect_to attendances_url, notice: "Attendance was successfully destroyed." }
+        format.json { head :no_content }
+      end
+    end
+  
+    private
+      # Use callbacks to share common setup or constraints between actions.
+      def set_attendance
+        @attendance = Attendance.find(params[:id])
+      end
+  
+      # Only allow a list of trusted parameters through.
+      def attendance_params
+        params.require(:attendance).permit(:event_id, :user_id, :attendance_id)
+      end
+  end
+  

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,70 @@
+class EventsController < ApplicationController
+  before_action :set_event, only: %i[ show edit update destroy ]
+
+  # GET /events or /events.json
+  def index
+    @events = Event.all
+  end
+
+  # GET /events/1 or /events/1.json
+  def show
+  end
+
+  # GET /events/new
+  def new
+    @event = Event.new
+  end
+
+  # GET /events/1/edit
+  def edit
+  end
+
+  # POST /events or /events.json
+  def create
+    @event = Event.new(event_params)
+
+    respond_to do |format|
+      if @event.save
+        format.html { redirect_to event_url(@event), notice: "Event was successfully created." }
+        format.json { render :show, status: :created, location: @event }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @event.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /events/1 or /events/1.json
+  def update
+    respond_to do |format|
+      if @event.update(event_params)
+        format.html { redirect_to event_url(@event), notice: "Event was successfully updated." }
+        format.json { render :show, status: :ok, location: @event }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @event.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /events/1 or /events/1.json
+  def destroy
+    @event.destroy
+
+    respond_to do |format|
+      format.html { redirect_to events_url, notice: "Event was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_event
+      @event = Event.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def event_params
+      params.require(:event).permit(:event_id, :title, :description, :date)
+    end
+end

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -1,0 +1,71 @@
+class RolesController < ApplicationController
+    before_action :set_role, only: %i[ show edit update destroy ]
+  
+    # GET /roles or /roles.json
+    def index
+      @roles = Role.all
+    end
+  
+    # GET /roles/1 or /roles/1.json
+    def show
+    end
+  
+    # GET /roles/new
+    def new
+      @role = Role.new
+    end
+  
+    # GET /roles/1/edit
+    def edit
+    end
+  
+    # POST /roles or /roles.json
+    def create
+      @role = Role.new(role_params)
+  
+      respond_to do |format|
+        if @role.save
+          format.html { redirect_to role_url(@role), notice: "Role was successfully created." }
+          format.json { render :show, status: :created, location: @role }
+        else
+          format.html { render :new, status: :unprocessable_entity }
+          format.json { render json: @role.errors, status: :unprocessable_entity }
+        end
+      end
+    end
+  
+    # PATCH/PUT /roles/1 or /roles/1.json
+    def update
+      respond_to do |format|
+        if @role.update(role_params)
+          format.html { redirect_to role_url(@role), notice: "Role was successfully updated." }
+          format.json { render :show, status: :ok, location: @role }
+        else
+          format.html { render :edit, status: :unprocessable_entity }
+          format.json { render json: @role.errors, status: :unprocessable_entity }
+        end
+      end
+    end
+  
+    # DELETE /roles/1 or /roles/1.json
+    def destroy
+      @role.destroy
+  
+      respond_to do |format|
+        format.html { redirect_to roles_url, notice: "Role was successfully destroyed." }
+        format.json { head :no_content }
+      end
+    end
+  
+    private
+      # Use callbacks to share common setup or constraints between actions.
+      def set_role
+        @role = Role.find(params[:id])
+      end
+  
+      # Only allow a list of trusted parameters through.
+      def role_params
+        params.require(:role).permit(:role_id, :is_officer, :is_admin, :title)
+      end
+  end
+  

--- a/app/controllers/timeslots_controller.rb
+++ b/app/controllers/timeslots_controller.rb
@@ -1,0 +1,71 @@
+class TimeslotsController < ApplicationController
+    before_action :set_timeslot, only: %i[ show edit update destroy ]
+  
+    # GET /timeslots or /timeslots.json
+    def index
+      @timeslots = Timeslot.all
+    end
+  
+    # GET /timeslots/1 or /timeslots/1.json
+    def show
+    end
+  
+    # GET /timeslots/new
+    def new
+      @timeslot = Timeslot.new
+    end
+  
+    # GET /timeslots/1/edit
+    def edit
+    end
+  
+    # POST /timeslots or /timeslots.json
+    def create
+      @timeslot = Timeslot.new(timeslot_params)
+  
+      respond_to do |format|
+        if @timeslot.save
+          format.html { redirect_to timeslot_url(@timeslot), notice: "Timeslot was successfully created." }
+          format.json { render :show, status: :created, location: @timeslot }
+        else
+          format.html { render :new, status: :unprocessable_entity }
+          format.json { render json: @timeslot.errors, status: :unprocessable_entity }
+        end
+      end
+    end
+  
+    # PATCH/PUT /timeslots/1 or /timeslots/1.json
+    def update
+      respond_to do |format|
+        if @timeslot.update(timeslot_params)
+          format.html { redirect_to timeslot_url(@timeslot), notice: "Timeslot was successfully updated." }
+          format.json { render :show, status: :ok, location: @timeslot }
+        else
+          format.html { render :edit, status: :unprocessable_entity }
+          format.json { render json: @timeslot.errors, status: :unprocessable_entity }
+        end
+      end
+    end
+  
+    # DELETE /timeslots/1 or /timeslots/1.json
+    def destroy
+      @timeslot.destroy
+  
+      respond_to do |format|
+        format.html { redirect_to timeslots_url, notice: "Timeslot was successfully destroyed." }
+        format.json { head :no_content }
+      end
+    end
+  
+    private
+      # Use callbacks to share common setup or constraints between actions.
+      def set_timeslot
+        @timeslot = Timeslot.find(params[:id])
+      end
+  
+      # Only allow a list of trusted parameters through.
+      def timeslot_params
+        params.require(:timeslot).permit(:timeslot_id, :attendance_id, :attend_time_start, :attend_time_end, :event_time_start, :event_time_end)
+      end
+  end
+  

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -1,0 +1,2 @@
+class Attendance < ApplicationRecord
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,2 @@
+class Event < ApplicationRecord
+end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,0 +1,2 @@
+class Role < ApplicationRecord
+end

--- a/app/models/timeslot.rb
+++ b/app/models/timeslot.rb
@@ -1,0 +1,2 @@
+class Timeslot < ApplicationRecord
+end

--- a/app/views/attendances/_attendance.json.jbuilder
+++ b/app/views/attendances/_attendance.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! attendance, :id, :event_id, :user_id, :attendance_id, :created_at, :updated_at
+json.url attendance_url(attendance, format: :json)

--- a/app/views/attendances/_form.html.erb
+++ b/app/views/attendances/_form.html.erb
@@ -1,0 +1,32 @@
+<%= form_with(model: attendance) do |form| %>
+  <% if attendance.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(attendance.errors.count, "error") %> prohibited this attendance from being saved:</h2>
+
+      <ul>
+        <% attendance.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :event_id %>
+    <%= form.number_field :event_id %>
+  </div>
+
+  <div class="field">
+    <%= form.label :user_id %>
+    <%= form.number_field :user_id %>
+  </div>
+
+  <div class="field">
+    <%= form.label :attendance_id %>
+    <%= form.number_field :attendance_id %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Attendance</h1>
+
+<%= render 'form', attendance: @attendance %>
+
+<%= link_to 'Show', @attendance %> |
+<%= link_to 'Back', attendances_path %>

--- a/app/views/attendances/index.html.erb
+++ b/app/views/attendances/index.html.erb
@@ -1,0 +1,31 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Attendance Records</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Event ID</th>
+      <th>User ID</th>
+      <th>Attendance ID</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @attendances.each do |attendance| %>
+      <tr>
+        <td><%= attendance.event_id %></td>
+        <td><%= attendance.user_id %></td>
+        <td><%= attendance.attendance_id %></td>
+        <td><%= link_to 'Show', attendance %></td>
+        <td><%= link_to 'Edit', edit_attendance_path(attendance) %></td>
+        <td><%= link_to 'Destroy', attendance, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Attendance Record', new_attendance_path %>

--- a/app/views/attendances/index.json.jbuilder
+++ b/app/views/attendances/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @attendances, partial: "attendances/attendance", as: :attendance

--- a/app/views/attendances/new.html.erb
+++ b/app/views/attendances/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Attendance Record</h1>
+
+<%= render 'form', attendance: @attendance %>
+
+<%= link_to 'Back', attendances_path %>

--- a/app/views/attendances/show.html.erb
+++ b/app/views/attendances/show.html.erb
@@ -1,0 +1,19 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Event ID:</strong>
+  <%= @attendance.event_id %>
+</p>
+
+<p>
+  <strong>User ID:</strong>
+  <%= @attendance.user_id %>
+</p>
+
+<p>
+  <strong>Attendance ID:</strong>
+  <%= @attendance.attendance_id %>
+</p>
+
+<%= link_to 'Edit', edit_attendance_path(@attendance) %> |
+<%= link_to 'Back', attendances_path %>

--- a/app/views/attendances/show.json.jbuilder
+++ b/app/views/attendances/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "attendances/attendance", attendance: @attendance

--- a/app/views/events/_event.json.jbuilder
+++ b/app/views/events/_event.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! event, :id, :event_id, :title, :description, :date, :created_at, :updated_at
+json.url event_url(event, format: :json)

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,0 +1,37 @@
+<%= form_with(model: event) do |form| %>
+  <% if event.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(event.errors.count, "error") %> prohibited this event from being saved:</h2>
+
+      <ul>
+        <% event.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :event_id %>
+    <%= form.number_field :event_id %>
+  </div>
+
+  <div class="field">
+    <%= form.label :title %>
+    <%= form.text_field :title %>
+  </div>
+
+  <div class="field">
+    <%= form.label :description %>
+    <%= form.text_field :description %>
+  </div>
+
+  <div class="field">
+    <%= form.label :date %>
+    <%= form.date_field :date %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Event</h1>
+
+<%= render 'form', event: @event %>
+
+<%= link_to 'Show', @event %> |
+<%= link_to 'Back', events_path %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,0 +1,33 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Events</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Event ID</th>
+      <th>Title</th>
+      <th>Description</th>
+      <th>Date</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @events.each do |event| %>
+      <tr>
+        <td><%= event.event_id %></td>
+        <td><%= event.title %></td>
+        <td><%= event.description %></td>
+        <td><%= event.date %></td>
+        <td><%= link_to 'Show', event %></td>
+        <td><%= link_to 'Edit', edit_event_path(event) %></td>
+        <td><%= link_to 'Destroy', event, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Event', new_event_path %>

--- a/app/views/events/index.json.jbuilder
+++ b/app/views/events/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @events, partial: "events/event", as: :event

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Event</h1>
+
+<%= render 'form', event: @event %>
+
+<%= link_to 'Back', events_path %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,0 +1,24 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Event ID:</strong>
+  <%= @event.event_id %>
+</p>
+
+<p>
+  <strong>Title:</strong>
+  <%= @event.title %>
+</p>
+
+<p>
+  <strong>Description:</strong>
+  <%= @event.description %>
+</p>
+
+<p>
+  <strong>Date:</strong>
+  <%= @event.date %>
+</p>
+
+<%= link_to 'Edit', edit_event_path(@event) %> |
+<%= link_to 'Back', events_path %>

--- a/app/views/events/show.json.jbuilder
+++ b/app/views/events/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "events/event", event: @event

--- a/app/views/roles/_form.html.erb
+++ b/app/views/roles/_form.html.erb
@@ -1,0 +1,37 @@
+<%= form_with(model: role) do |form| %>
+  <% if role.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(role.errors.count, "error") %> prohibited this role from being saved:</h2>
+
+      <ul>
+        <% role.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :role_id %>
+    <%= form.number_field :role_id %>
+  </div>
+
+  <div class="field">
+    <%= form.label :is_officer %>
+    <%= form.check_box :is_officer %>
+  </div>
+
+  <div class="field">
+    <%= form.label :is_admin %>
+    <%= form.check_box :is_admin %>
+  </div>
+
+  <div class="field">
+    <%= form.label :title %>
+    <%= form.text_field :title %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/roles/_role.json.jbuilder
+++ b/app/views/roles/_role.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! role, :id, :role_id, :is_officer, :is_admin, :title, :created_at, :updated_at
+json.url role_url(role, format: :json)

--- a/app/views/roles/edit.html.erb
+++ b/app/views/roles/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Role</h1>
+
+<%= render 'form', role: @role %>
+
+<%= link_to 'Show', @role %> |
+<%= link_to 'Back', roles_path %>

--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -1,0 +1,33 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Roles</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Role ID</th>
+      <th>Officer?</th>
+      <th>Admin?</th>
+      <th>Title</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @roles.each do |role| %>
+      <tr>
+        <td><%= role.role_id %></td>
+        <td><%= role.is_officer %></td>
+        <td><%= role.is_admin %></td>
+        <td><%= role.title %></td>
+        <td><%= link_to 'Show', role %></td>
+        <td><%= link_to 'Edit', edit_role_path(role) %></td>
+        <td><%= link_to 'Destroy', role, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Role', new_role_path %>

--- a/app/views/roles/index.json.jbuilder
+++ b/app/views/roles/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @roles, partial: "roles/role", as: :role

--- a/app/views/roles/new.html.erb
+++ b/app/views/roles/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Role</h1>
+
+<%= render 'form', role: @role %>
+
+<%= link_to 'Back', roles_path %>

--- a/app/views/roles/show.html.erb
+++ b/app/views/roles/show.html.erb
@@ -1,0 +1,24 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Role ID:</strong>
+  <%= @role.role_id %>
+</p>
+
+<p>
+  <strong>Officer?</strong>
+  <%= @role.is_officer %>
+</p>
+
+<p>
+  <strong>Admin?</strong>
+  <%= @role.is_admin %>
+</p>
+
+<p>
+  <strong>Title:</strong>
+  <%= @role.title %>
+</p>
+
+<%= link_to 'Edit', edit_role_path(@role) %> |
+<%= link_to 'Back', roles_path %>

--- a/app/views/roles/show.json.jbuilder
+++ b/app/views/roles/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "roles/role", role: @role

--- a/app/views/timeslots/_form.html.erb
+++ b/app/views/timeslots/_form.html.erb
@@ -1,0 +1,47 @@
+<%= form_with(model: timeslot) do |form| %>
+  <% if timeslot.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(timeslot.errors.count, "error") %> prohibited this timeslot from being saved:</h2>
+
+      <ul>
+        <% timeslot.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :timeslot_id %>
+    <%= form.number_field :timeslot_id %>
+  </div>
+
+  <div class="field">
+    <%= form.label :attendance_id %>
+    <%= form.number_field :attendance_id %>
+  </div>
+
+  <div class="field">
+    <%= form.label :attend_time_start %>
+    <%= form.time_field :attend_time_start %>
+  </div>
+
+  <div class="field">
+    <%= form.label :attend_time_end %>
+    <%= form.time_field :attend_time_end %>
+  </div>
+
+  <div class="field">
+    <%= form.label :event_time_start %>
+    <%= form.time_field :event_time_start %>
+  </div>
+
+  <div class="field">
+    <%= form.label :event_time_end %>
+    <%= form.time_field :event_time_end %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/timeslots/_timeslot.json.jbuilder
+++ b/app/views/timeslots/_timeslot.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! timeslot, :id, :timeslot_id, :attendance_id, :attend_time_start, :attend_time_end, :event_time_start, :event_time_end, :created_at, :updated_at
+json.url timeslot_url(timeslot, format: :json)

--- a/app/views/timeslots/edit.html.erb
+++ b/app/views/timeslots/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Timeslot</h1>
+
+<%= render 'form', timeslot: @timeslot %>
+
+<%= link_to 'Show', @timeslot %> |
+<%= link_to 'Back', timeslots_path %>

--- a/app/views/timeslots/index.html.erb
+++ b/app/views/timeslots/index.html.erb
@@ -1,0 +1,37 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Timeslot</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Timeslot ID</th>
+      <th>Attendance ID</th>
+      <th>Attend Time Start</th>
+      <th>Attend Time End</th>
+      <th>Event Time Start</th>
+      <th>Event Time End</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @timeslots.each do |timeslot| %>
+      <tr>
+        <td><%= timeslot.timeslot_id %></td>
+        <td><%= timeslot.attendance_id %></td>
+        <td><%= timeslot.attend_time_start %></td>
+        <td><%= timeslot.attend_time_end %></td>
+        <td><%= timeslot.event_time_start %></td>
+        <td><%= timeslot.event_time_end %></td>
+        <td><%= link_to 'Show', timeslot %></td>
+        <td><%= link_to 'Edit', edit_timeslot_path(timeslot) %></td>
+        <td><%= link_to 'Destroy', timeslot, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Timeslot', new_timeslot_path %>

--- a/app/views/timeslots/index.json.jbuilder
+++ b/app/views/timeslots/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @timeslots, partial: "timeslots/timeslot", as: :timeslot

--- a/app/views/timeslots/new.html.erb
+++ b/app/views/timeslots/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Timeslot</h1>
+
+<%= render 'form', timeslot: @timeslot %>
+
+<%= link_to 'Back', timeslots_path %>

--- a/app/views/timeslots/show.html.erb
+++ b/app/views/timeslots/show.html.erb
@@ -1,0 +1,34 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Timeslot ID:</strong>
+  <%= @timeslot.timeslot_id %>
+</p>
+
+<p>
+  <strong>Attendance ID:</strong>
+  <%= @timeslot.attendance_id %>
+</p>
+
+<p>
+  <strong>Attend Time Start:</strong>
+  <%= @timeslot.attend_time_start %>
+</p>
+
+<p>
+  <strong>Attend Time End:</strong>
+  <%= @timeslot.attend_time_end %>
+</p>
+
+<p>
+  <strong>Event Time Start:</strong>
+  <%= @timeslot.event_time_start %>
+</p>
+
+<p>
+  <strong>Event Time End:</strong>
+  <%= @timeslot.event_time_end %>
+</p>
+
+<%= link_to 'Edit', edit_timeslot_path(@timeslot) %> |
+<%= link_to 'Back', timeslots_path %>

--- a/app/views/timeslots/show.json.jbuilder
+++ b/app/views/timeslots/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! "timeslots/timeslot", user: @user
+json.partial! "timeslots/timeslot", timeslot: @timeslot

--- a/app/views/timeslots/show.json.jbuilder
+++ b/app/views/timeslots/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "timeslots/timeslot", user: @user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  resources :timeslots
+  resources :events
+  resources :attendances
+  resources :roles
   resources :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20220209055759_timeslots.rb
+++ b/db/migrate/20220209055759_timeslots.rb
@@ -1,0 +1,14 @@
+class Timeslots < ActiveRecord::Migration[6.1]
+  def change
+    create_table :timeslots do |t|
+      t.integer :timeslot_id
+      t.integer :attendance_id
+      t.time :attend_time_start
+      t.time :attend_time_end
+      t.time :event_time_start
+      t.time :event_time_end
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220209062423_events.rb
+++ b/db/migrate/20220209062423_events.rb
@@ -1,0 +1,12 @@
+class Events < ActiveRecord::Migration[6.1]
+  def change
+    create_table :events do |t|
+      t.integer :event_id
+      t.string :title
+      t.string :description
+      t.date :date
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220209062648_attendances.rb
+++ b/db/migrate/20220209062648_attendances.rb
@@ -1,0 +1,11 @@
+class Attendances < ActiveRecord::Migration[6.1]
+  def change
+    create_table :attendances do |t|
+      t.integer :event_id
+      t.integer :user_id
+      t.integer :attendance_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220209062653_roles.rb
+++ b/db/migrate/20220209062653_roles.rb
@@ -1,0 +1,12 @@
+class Roles < ActiveRecord::Migration[6.1]
+  def change
+    create_table :roles do |t|
+      t.integer :role_id
+      t.boolean :is_officer
+      t.boolean :is_admin
+      t.string :title
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,36 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_09_055759) do
+ActiveRecord::Schema.define(version: 2022_02_09_062653) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "attendances", force: :cascade do |t|
+    t.integer "event_id"
+    t.integer "user_id"
+    t.integer "attendance_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "events", force: :cascade do |t|
+    t.integer "event_id"
+    t.string "title"
+    t.string "description"
+    t.date "date"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "roles", force: :cascade do |t|
+    t.integer "role_id"
+    t.boolean "is_officer"
+    t.boolean "is_admin"
+    t.string "title"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "timeslots", force: :cascade do |t|
     t.integer "timeslot_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,47 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_07_203952) do
+ActiveRecord::Schema.define(version: 2022_02_09_040158) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "attendances", force: :cascade do |t|
+    t.integer "event_id"
+    t.integer "user_id"
+    t.integer "attendance_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "events", force: :cascade do |t|
+    t.integer "event_id"
+    t.string "title"
+    t.string "description"
+    t.date "date"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "roles", force: :cascade do |t|
+    t.integer "role_id"
+    t.boolean "is_officer"
+    t.boolean "is_admin"
+    t.string "title"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "timeslots", force: :cascade do |t|
+    t.integer "timeslot_id"
+    t.integer "attendance_id"
+    t.time "attend_time_start"
+    t.time "attend_time_end"
+    t.time "event_time_start"
+    t.time "event_time_end"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,36 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_09_040158) do
+ActiveRecord::Schema.define(version: 2022_02_09_055759) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "attendances", force: :cascade do |t|
-    t.integer "event_id"
-    t.integer "user_id"
-    t.integer "attendance_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
-  create_table "events", force: :cascade do |t|
-    t.integer "event_id"
-    t.string "title"
-    t.string "description"
-    t.date "date"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
-  create_table "roles", force: :cascade do |t|
-    t.integer "role_id"
-    t.boolean "is_officer"
-    t.boolean "is_admin"
-    t.string "title"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
 
   create_table "timeslots", force: :cascade do |t|
     t.integer "timeslot_id"


### PR DESCRIPTION
Previously, going to /<entity>/ path yielded an error for all but the /users/ path.

In this pull request, the following entities were implemented:
/timeslots/
/events/
/attendances/
/roles/

Additionally, a database migration was created for each of the entities.
- this means there is now a table for each entity (ie: timeslots table)